### PR TITLE
Fix #15: Codex agent fails to use gh CLI due to sandbox restrictions

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -297,7 +297,8 @@ async fn run_agent_process(
         .output()
         .ok()
         .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|t| !t.is_empty());
 
     let mut command = Command::new(&cmd);
     command


### PR DESCRIPTION
## Summary

- Add `--add-dir ~/.config/gh` to Codex CLI args so the sandbox allows reading gh auth config
- Inject `GH_TOKEN` env var (obtained via `gh auth token`) into all agent subprocess environments
- Both changes ensure Codex can interact with the GitHub API despite its `--full-auto` sandbox

Closes #15

## Test plan

- [ ] Launch a pipeline with Codex as the agent and verify gh commands (pr create, pr list, etc.) succeed
- [ ] Verify Claude agent still works correctly (GH_TOKEN injection is additive)
- [ ] Test with a user that has no `~/.config/gh` directory (the `--add-dir` is skipped gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)