### PR TITLE
Fix #20: Pipeline Report shows +0/-0 lines: diff stats not captured from agent output

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -176,6 +176,9 @@ pub async fn launch_agent(
         error: None,
         attempt: 1,
         max_retries,
+        lines_added: 0,
+        lines_removed: 0,
+        files_modified_list: Vec::new(),
         report: None,
     };
 
@@ -468,6 +471,18 @@ async fn run_agent_process(
         }),
     );
 
+    // After agent completes successfully, capture actual diff stats from git
+    if succeeded {
+        let (diff_added, diff_removed, diff_files) =
+            capture_diff_stats(&workspace_path).await;
+        let mut s = state.lock().await;
+        if let Some(run) = s.runs.get_mut(&run_id) {
+            run.lines_added = diff_added;
+            run.lines_removed = diff_removed;
+            run.files_modified_list = diff_files;
+        }
+    }
+
     // RETRY LOGIC: If the agent failed, check if we can retry
     if !succeeded {
         let (current_attempt, max_retries, retry_backoff, error_log) = {
@@ -577,6 +592,9 @@ async fn run_agent_process(
                     error: None,
                     attempt: 1,
                     max_retries: 0,
+                    lines_added: 0,
+                    lines_removed: 0,
+                    files_modified_list: Vec::new(),
                     report: Some(pipeline_report.clone()),
                 };
                 {
@@ -668,6 +686,9 @@ fn spawn_next_stage(
             error: None,
             attempt: 1,
             max_retries: config.max_retries,
+            lines_added: 0,
+            lines_removed: 0,
+            files_modified_list: Vec::new(),
             report: None,
         };
 
@@ -765,6 +786,9 @@ fn spawn_retry(
             error: None,
             attempt,
             max_retries,
+            lines_added: 0,
+            lines_removed: 0,
+            files_modified_list: Vec::new(),
             report: None,
         };
 
@@ -820,6 +844,66 @@ async fn update_dock_badge(state: &SharedState) {
         })
         .count();
     crate::dock::set_badge_count(active);
+}
+
+/// Run `git diff --stat origin/main...HEAD` in the workspace and parse the output.
+async fn capture_diff_stats(workspace_path: &std::path::Path) -> (u32, u32, Vec<String>) {
+    let output = Command::new("git")
+        .args(["diff", "--stat", "origin/main...HEAD"])
+        .current_dir(workspace_path)
+        .env("PATH", crate::paths::build_path_env())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .output()
+        .await;
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            parse_git_diff_stat(&stdout)
+        }
+        _ => (0, 0, Vec::new()),
+    }
+}
+
+fn parse_git_diff_stat(output: &str) -> (u32, u32, Vec<String>) {
+    let mut added: u32 = 0;
+    let mut removed: u32 = 0;
+    let mut files: Vec<String> = Vec::new();
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        // Summary line: "3 files changed, 45 insertions(+), 12 deletions(-)"
+        if trimmed.contains("changed")
+            && (trimmed.contains("insertion") || trimmed.contains("deletion"))
+        {
+            for part in trimmed.split(',') {
+                let part = part.trim();
+                if part.contains("insertion") {
+                    if let Some(num) = part.split_whitespace().next() {
+                        added = num.parse().unwrap_or(0);
+                    }
+                }
+                if part.contains("deletion") {
+                    if let Some(num) = part.split_whitespace().next() {
+                        removed = num.parse().unwrap_or(0);
+                    }
+                }
+            }
+        }
+        // File lines: " src/agent.rs | 15 +++---"
+        else if trimmed.contains(" | ") {
+            if let Some(pos) = trimmed.find(" | ") {
+                let file = trimmed[..pos].trim().to_string();
+                if !file.is_empty() {
+                    files.push(file);
+                }
+            }
+        }
+    }
+
+    (added, removed, files)
 }
 
 #[tauri::command]

--- a/src-tauri/src/orchestrator.rs
+++ b/src-tauri/src/orchestrator.rs
@@ -52,6 +52,9 @@ pub struct AgentRun {
     pub error: Option<String>,
     pub attempt: u32,
     pub max_retries: u32,
+    pub lines_added: u32,
+    pub lines_removed: u32,
+    pub files_modified_list: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub report: Option<crate::report::PipelineReport>,
 }

--- a/src-tauri/src/report.rs
+++ b/src-tauri/src/report.rs
@@ -55,8 +55,18 @@ pub fn generate_report(
             let duration_secs = calculate_duration(&run.started_at, &run.finished_at);
             total_duration += duration_secs.unwrap_or(0);
 
-            let files = extract_files_modified(&run.logs);
-            let (added, removed) = extract_diff_stats(&run.logs);
+            // Use stored diff stats from git (captured after agent success)
+            // Fall back to log parsing only if stored stats are empty
+            let files = if !run.files_modified_list.is_empty() {
+                run.files_modified_list.clone()
+            } else {
+                extract_files_modified(&run.logs)
+            };
+            let (added, removed) = if run.lines_added > 0 || run.lines_removed > 0 {
+                (run.lines_added, run.lines_removed)
+            } else {
+                extract_diff_stats(&run.logs)
+            };
             let commands = extract_commands(&run.logs);
             let summary = extract_stage_summary(stage_name, &run.logs);
 


### PR DESCRIPTION
## Summary

- Added `lines_added`, `lines_removed`, and `files_modified_list` fields to `AgentRun` struct
- Implemented `capture_diff_stats()` that runs `git diff --stat origin/main...HEAD` directly against the workspace after each successful agent stage
- Report generation now uses stored git stats with fallback to log parsing for backwards compatibility

Closes #20