### PR TITLE
Fix #28: Add token and cost aggregation across runs

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -360,6 +360,33 @@ fn parse_stream_json_event(raw: &str) -> Vec<String> {
     }
 }
 
+/// Token usage extracted from a Claude CLI result event.
+pub struct TokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+    pub duration_secs: f64,
+}
+
+/// Try to extract token usage from a stream-json result event line.
+fn parse_token_usage(raw: &str) -> Option<TokenUsage> {
+    let parsed: serde_json::Value = serde_json::from_str(raw).ok()?;
+    if parsed["type"].as_str() != Some("result") {
+        return None;
+    }
+    let usage = &parsed["usage"];
+    let input_tokens = usage["input_tokens"].as_u64().unwrap_or(0);
+    let output_tokens = usage["output_tokens"].as_u64().unwrap_or(0);
+    let cost_usd = parsed["total_cost_usd"].as_f64().unwrap_or(0.0);
+    let duration_ms = parsed["duration_ms"].as_u64().unwrap_or(0);
+    Some(TokenUsage {
+        input_tokens,
+        output_tokens,
+        cost_usd,
+        duration_secs: duration_ms as f64 / 1000.0,
+    })
+}
+
 /// Truncate a JSON value to a max character length for display.
 fn truncate_json(value: &serde_json::Value, max_len: usize) -> String {
     let s = value.to_string();
@@ -454,6 +481,9 @@ pub async fn launch_agent(
         last_log_line: None,
         log_count: 0,
         activity: None,
+        input_tokens: 0,
+        output_tokens: 0,
+        cost_usd: 0.0,
     };
 
     {
@@ -680,6 +710,9 @@ async fn run_agent_process(
                 // Try to parse as stream-json event from Claude CLI
                 let display_lines = parse_stream_json_event(&line);
 
+                // Extract token usage from result events
+                let token_usage = parse_token_usage(&line);
+
                 for display_line in &display_lines {
                     let ts = Utc::now().to_rfc3339();
                     let log_line = AgentLogLine {
@@ -699,6 +732,20 @@ async fn run_agent_process(
                             run.activity = Some(act.clone());
                         }
                     }
+                }
+
+                // Accumulate token usage into run and global totals
+                if let Some(ref usage) = token_usage {
+                    let mut s = state_out.lock().await;
+                    if let Some(run) = s.runs.get_mut(&run_id_out) {
+                        run.input_tokens += usage.input_tokens;
+                        run.output_tokens += usage.output_tokens;
+                        run.cost_usd += usage.cost_usd;
+                    }
+                    s.total_input_tokens += usage.input_tokens;
+                    s.total_output_tokens += usage.output_tokens;
+                    s.total_cost_usd += usage.cost_usd;
+                    s.total_runtime_secs += usage.duration_secs;
                 }
             }
         }
@@ -980,6 +1027,22 @@ async fn run_agent_process(
                     (all_logs, report)
                 };
 
+                // Aggregate token usage across all stage runs for this issue
+                let (total_input, total_output, total_cost) = {
+                    let s = state.lock().await;
+                    let mut inp: u64 = 0;
+                    let mut out: u64 = 0;
+                    let mut cost: f64 = 0.0;
+                    for r in s.runs.values() {
+                        if r.issue_number == issue_number && r.stage != PipelineStage::Done {
+                            inp += r.input_tokens;
+                            out += r.output_tokens;
+                            cost += r.cost_usd;
+                        }
+                    }
+                    (inp, out, cost)
+                };
+
                 let done_run = AgentRun {
                     id: done_id.clone(),
                     repo: repo.clone(),
@@ -1003,6 +1066,9 @@ async fn run_agent_process(
                     last_log_line: None,
                     log_count: 0,
                     activity: Some("Completed".to_string()),
+                    input_tokens: total_input,
+                    output_tokens: total_output,
+                    cost_usd: total_cost,
                 };
                 {
                     let mut s = state.lock().await;
@@ -1125,6 +1191,9 @@ fn spawn_next_stage(
             last_log_line: None,
             log_count: 0,
             activity: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
         };
 
         {
@@ -1256,6 +1325,9 @@ fn spawn_retry(
             last_log_line: None,
             log_count: 0,
             activity: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
         };
 
         {

--- a/src-tauri/src/orchestrator.rs
+++ b/src-tauri/src/orchestrator.rs
@@ -67,6 +67,10 @@ pub struct AgentRun {
     pub log_count: u32,
     /// Detected activity state from log content
     pub activity: Option<String>,
+    /// Token usage from Claude result events
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -150,6 +154,10 @@ pub struct OrchestratorStatus {
     pub total_completed: usize,
     pub total_failed: usize,
     pub active_count: usize,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_cost_usd: f64,
+    pub total_runtime_secs: f64,
 }
 
 pub struct OrchestratorState {
@@ -159,6 +167,11 @@ pub struct OrchestratorState {
     pub config: RunConfig,
     pub agent_pids: HashMap<String, u32>,
     pub stop_flag: bool,
+    /// Cumulative token and cost totals across all runs
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_cost_usd: f64,
+    pub total_runtime_secs: f64,
 }
 
 impl OrchestratorState {
@@ -170,6 +183,10 @@ impl OrchestratorState {
             config: RunConfig::default(),
             agent_pids: HashMap::new(),
             stop_flag: false,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cost_usd: 0.0,
+            total_runtime_secs: 0.0,
         }
     }
 
@@ -209,6 +226,10 @@ pub async fn get_status(
         total_completed,
         total_failed,
         active_count,
+        total_input_tokens: s.total_input_tokens,
+        total_output_tokens: s.total_output_tokens,
+        total_cost_usd: s.total_cost_usd,
+        total_runtime_secs: s.total_runtime_secs,
     })
 }
 

--- a/src-tauri/src/report.rs
+++ b/src-tauri/src/report.rs
@@ -28,6 +28,9 @@ pub struct PipelineReport {
     pub issue_url: String,
     pub code_review_summary: String,
     pub testing_summary: String,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_cost_usd: f64,
 }
 
 pub fn generate_report(
@@ -42,6 +45,9 @@ pub fn generate_report(
     let mut pr_url: Option<String> = None;
     let mut code_review_summary = String::new();
     let mut testing_summary = String::new();
+    let mut total_input_tokens: u64 = 0;
+    let mut total_output_tokens: u64 = 0;
+    let mut total_cost_usd: f64 = 0.0;
 
     let stage_order = ["implement", "code_review", "testing", "merge"];
 
@@ -87,6 +93,10 @@ pub fn generate_report(
                 testing_summary = summary.clone();
             }
 
+            total_input_tokens += run.input_tokens;
+            total_output_tokens += run.output_tokens;
+            total_cost_usd += run.cost_usd;
+
             stages.push(StageReport {
                 name: format_stage_name(stage_name),
                 status: run.status.clone().into(),
@@ -116,6 +126,9 @@ pub fn generate_report(
         issue_url,
         code_review_summary,
         testing_summary,
+        total_input_tokens,
+        total_output_tokens,
+        total_cost_usd,
     }
 }
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -38,6 +38,10 @@ interface OrchestratorStatus {
   total_completed: number;
   total_failed: number;
   active_count: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cost_usd: number;
+  total_runtime_secs: number;
 }
 
 type KanbanCard = {
@@ -133,15 +137,21 @@ export function Dashboard({ onViewLogs, onViewReport }: { onViewLogs: (runId: st
     } catch (e) { setError(String(e)); }
   }
 
-  function formatElapsed(startedAt: string, finishedAt: string | null): string {
-    const start = new Date(startedAt).getTime();
-    const end = finishedAt ? new Date(finishedAt).getTime() : Date.now();
-    const secs = Math.floor((end - start) / 1000);
+  function formatElapsed(startedAt: string, finishedAt: string | null, totalSecs?: number): string {
+    const secs = totalSecs !== undefined
+      ? Math.floor(totalSecs)
+      : Math.floor((( finishedAt ? new Date(finishedAt).getTime() : Date.now()) - new Date(startedAt).getTime()) / 1000);
     if (secs < 60) return `${secs}s`;
     const mins = Math.floor(secs / 60);
     if (mins < 60) return `${mins}m ${secs % 60}s`;
     const hours = Math.floor(mins / 60);
     return `${hours}h ${mins % 60}m`;
+  }
+
+  function formatTokens(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return n.toString();
   }
 
   function formatDate(dateStr: string): string {
@@ -302,6 +312,41 @@ export function Dashboard({ onViewLogs, onViewReport }: { onViewLogs: (runId: st
       {error && (
         <div className="mx-6 mt-3 bg-[#f8514926] border border-[#f85149] rounded-lg p-3">
           <p className="text-[#f85149] text-sm">{error}</p>
+        </div>
+      )}
+
+      {/* Metrics Summary */}
+      {(status.total_cost_usd > 0 || status.total_input_tokens > 0) && (
+        <div className="mx-6 mt-3 flex items-center gap-6 bg-[#161b22] border border-[#30363d] rounded-lg px-4 py-2 text-xs shrink-0">
+          <div className="flex items-center gap-1.5 text-[#8b949e]">
+            <span className="text-[#e6edf3] font-medium">
+              {formatTokens(status.total_input_tokens + status.total_output_tokens)}
+            </span>
+            <span>tokens</span>
+          </div>
+          <div className="flex items-center gap-1.5 text-[#8b949e]">
+            <span className="text-[#e6edf3] font-medium">
+              {formatTokens(status.total_input_tokens)}
+            </span>
+            <span>in</span>
+            <span className="text-[#484f58]">/</span>
+            <span className="text-[#e6edf3] font-medium">
+              {formatTokens(status.total_output_tokens)}
+            </span>
+            <span>out</span>
+          </div>
+          <div className="flex items-center gap-1.5 text-[#8b949e]">
+            <span className="text-[#3fb950] font-medium">
+              ${status.total_cost_usd.toFixed(4)}
+            </span>
+            <span>cost</span>
+          </div>
+          <div className="flex items-center gap-1.5 text-[#8b949e]">
+            <span className="text-[#e6edf3] font-medium">
+              {formatElapsed("", null, status.total_runtime_secs)}
+            </span>
+            <span>runtime</span>
+          </div>
         </div>
       )}
 

--- a/src/components/PipelineReportView.tsx
+++ b/src/components/PipelineReportView.tsx
@@ -27,6 +27,9 @@ export interface PipelineReport {
   issue_url: string;
   code_review_summary: string;
   testing_summary: string;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cost_usd: number;
 }
 
 const STAGE_COLORS: Record<string, string> = {
@@ -115,6 +118,12 @@ export function PipelineReportView({
     );
   }
 
+  function formatTokens(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return n.toString();
+  }
+
   const totalFiles = report.stages.reduce((acc, s) => acc + s.files_modified.length, 0);
   const totalAdded = report.stages.reduce((acc, s) => acc + s.lines_added, 0);
   const totalRemoved = report.stages.reduce((acc, s) => acc + s.lines_removed, 0);
@@ -179,6 +188,28 @@ export function PipelineReportView({
             <div className="text-xs text-[#8b949e]">Lines Removed</div>
           </div>
         </div>
+
+        {/* Token & Cost Metrics */}
+        {(report.total_cost_usd > 0 || report.total_input_tokens > 0) && (
+          <div className="grid grid-cols-3 gap-3">
+            <div className="bg-[#161b22] border border-[#30363d] rounded-lg p-3 text-center">
+              <div className="text-lg font-bold text-[#e6edf3]">
+                {formatTokens(report.total_input_tokens + report.total_output_tokens)}
+              </div>
+              <div className="text-xs text-[#8b949e]">Total Tokens</div>
+            </div>
+            <div className="bg-[#161b22] border border-[#30363d] rounded-lg p-3 text-center">
+              <div className="text-lg font-bold text-[#e6edf3]">
+                {formatTokens(report.total_input_tokens)} / {formatTokens(report.total_output_tokens)}
+              </div>
+              <div className="text-xs text-[#8b949e]">Input / Output</div>
+            </div>
+            <div className="bg-[#161b22] border border-[#30363d] rounded-lg p-3 text-center">
+              <div className="text-lg font-bold text-[#3fb950]">${report.total_cost_usd.toFixed(4)}</div>
+              <div className="text-xs text-[#8b949e]">Total Cost</div>
+            </div>
+          </div>
+        )}
 
         {/* Time Breakdown */}
         <div className="bg-[#161b22] border border-[#30363d] rounded-lg p-4">


### PR DESCRIPTION
Closes #28

## Summary
- Parse `input_tokens`, `output_tokens`, and `total_cost_usd` from Claude's stream-json `result` events in `agent.rs`
- Accumulate per-run token/cost metrics in `AgentRun` and session-wide totals in `OrchestratorState`
- Display aggregate metrics bar (total tokens, input/output breakdown, cost, runtime) in Dashboard UI
- Show per-issue token/cost cards in `PipelineReportView` and include totals in `PipelineReport`

## Test plan
- [ ] Run an agent and verify token/cost metrics appear in the Dashboard metrics bar
- [ ] Complete a full pipeline and verify per-issue totals in the Pipeline Report view
- [ ] Verify metrics accumulate correctly across multiple concurrent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)