### PR TITLE
Fix #26: Replace fixed retry delay with exponential backoff

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3477,6 +3477,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
+ "tempfile",
  "tokio",
  "uuid",
 ]

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -881,7 +881,16 @@ async fn run_agent_process(
             let run = s.runs.get(&run_id);
             let attempt = run.map(|r| r.attempt).unwrap_or(1);
             let max_r = run.map(|r| r.max_retries).unwrap_or(0);
-            let backoff = s.config.retry_backoff_secs;
+            // Exponential backoff: min(base_delay * 2^(attempt-1), max_backoff)
+            let base_delay = if s.config.retry_base_delay_secs > 0 {
+                s.config.retry_base_delay_secs
+            } else {
+                // Backward compatibility: use retry_backoff_secs as base delay
+                s.config.retry_backoff_secs
+            };
+            let max_backoff = s.config.retry_max_backoff_secs;
+            let exp_backoff = base_delay.saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)));
+            let backoff = exp_backoff.min(max_backoff);
             let err = run.and_then(|r| r.error.clone()).unwrap_or_default();
             (attempt, max_r, backoff, err)
         };

--- a/src-tauri/src/orchestrator.rs
+++ b/src-tauri/src/orchestrator.rs
@@ -111,6 +111,10 @@ pub struct RunConfig {
     pub notification_sound: bool,
     pub max_retries: u32,
     pub retry_backoff_secs: u64,
+    #[serde(default = "default_retry_base_delay")]
+    pub retry_base_delay_secs: u64,
+    #[serde(default = "default_retry_max_backoff")]
+    pub retry_max_backoff_secs: u64,
     pub cleanup_on_failure: bool,
     pub cleanup_on_stop: bool,
     pub workspace_ttl_days: u32,
@@ -137,6 +141,14 @@ fn default_priority_labels() -> Vec<String> {
     ]
 }
 
+fn default_retry_base_delay() -> u64 {
+    10
+}
+
+fn default_retry_max_backoff() -> u64 {
+    300
+}
+
 impl Default for RunConfig {
     fn default() -> Self {
         Self {
@@ -150,6 +162,8 @@ impl Default for RunConfig {
             notification_sound: true,
             max_retries: 1,
             retry_backoff_secs: 10,
+            retry_base_delay_secs: default_retry_base_delay(),
+            retry_max_backoff_secs: default_retry_max_backoff(),
             cleanup_on_failure: false,
             cleanup_on_stop: false,
             workspace_ttl_days: 7,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ export interface RunConfig {
   notification_sound: boolean;
   max_retries: number;
   retry_backoff_secs: number;
+  retry_base_delay_secs: number;
+  retry_max_backoff_secs: number;
   cleanup_on_failure: boolean;
   cleanup_on_stop: boolean;
   workspace_ttl_days: number;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -31,6 +31,8 @@ export function Settings() {
     notification_sound: true,
     max_retries: 1,
     retry_backoff_secs: 10,
+    retry_base_delay_secs: 10,
+    retry_max_backoff_secs: 300,
     cleanup_on_failure: false,
     cleanup_on_stop: false,
     workspace_ttl_days: 7,
@@ -305,19 +307,37 @@ export function Settings() {
               </div>
 
               <div>
-                <label className="block text-sm text-[#8b949e] mb-2">Retry Backoff (seconds)</label>
+                <label className="block text-sm text-[#8b949e] mb-2">Retry Base Delay (seconds)</label>
                 <input
                   type="number"
                   min={1}
                   max={300}
-                  value={config.retry_backoff_secs}
+                  value={config.retry_base_delay_secs}
+                  onChange={(e) => {
+                    const val = parseInt(e.target.value) || 10;
+                    setConfig({ ...config, retry_base_delay_secs: val, retry_backoff_secs: val });
+                  }}
+                  className="w-full px-3 py-2 bg-[#0d1117] border border-[#30363d] rounded-md text-[#e6edf3] text-sm outline-none focus:border-[#58a6ff]"
+                />
+                <p className="text-xs text-[#8b949e] mt-1">
+                  Base delay for exponential backoff (delay = base × 2^(attempt−1)).
+                </p>
+              </div>
+
+              <div>
+                <label className="block text-sm text-[#8b949e] mb-2">Max Retry Backoff (seconds)</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={600}
+                  value={config.retry_max_backoff_secs}
                   onChange={(e) =>
-                    setConfig({ ...config, retry_backoff_secs: parseInt(e.target.value) || 10 })
+                    setConfig({ ...config, retry_max_backoff_secs: parseInt(e.target.value) || 300 })
                   }
                   className="w-full px-3 py-2 bg-[#0d1117] border border-[#30363d] rounded-md text-[#e6edf3] text-sm outline-none focus:border-[#58a6ff]"
                 />
                 <p className="text-xs text-[#8b949e] mt-1">
-                  Delay in seconds before retrying a failed stage.
+                  Maximum delay cap in seconds (default: 300s / 5 minutes).
                 </p>
               </div>
 


### PR DESCRIPTION
Closes #26

## Summary
- Replace fixed retry delay with exponential backoff: `min(base_delay * 2^(attempt-1), max_backoff)`
- Add `retry_base_delay_secs` (default 10s) and `retry_max_backoff_secs` (default 300s) to RunConfig
- Keep backward compatibility: falls back to `retry_backoff_secs` if `retry_base_delay_secs` is 0
- Update Settings UI with separate fields for base delay and max backoff