### PR TITLE
Fix #25: Re-check issue state between pipeline stages

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1171,6 +1171,58 @@ fn spawn_next_stage(
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         }
 
+        // Re-check issue/PR state before proceeding to the next stage
+        {
+            let repo_clone = repo.clone();
+            let issue_num = issue_number;
+            let stage_clone = stage.clone();
+            let stage_label_clone = stage_label.clone();
+
+            let skip = tokio::task::spawn_blocking(move || {
+                // Check if the issue has been closed externally
+                match crate::github::get_issue_state(&repo_clone, issue_num) {
+                    Ok(ref issue_state) if issue_state != "OPEN" => {
+                        eprintln!(
+                            "Issue #{issue_num} is {issue_state}; skipping stage {stage_label_clone}"
+                        );
+                        return true;
+                    }
+                    Err(ref e) => {
+                        eprintln!(
+                            "Warning: could not re-check issue #{issue_num} state: {e}; proceeding anyway"
+                        );
+                    }
+                    _ => {}
+                }
+
+                // If the next stage is Merge, check if the PR is already merged
+                if matches!(stage_clone, PipelineStage::Merge) {
+                    match crate::github::is_pr_merged_for_issue(&repo_clone, issue_num) {
+                        Ok(true) => {
+                            eprintln!(
+                                "PR for issue #{issue_num} is already merged; skipping Merge stage"
+                            );
+                            return true;
+                        }
+                        Err(ref e) => {
+                            eprintln!(
+                                "Warning: could not check PR merge status for #{issue_num}: {e}; proceeding anyway"
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+
+                false
+            })
+            .await
+            .unwrap_or(false);
+
+            if skip {
+                return;
+            }
+        }
+
         let run_id = Uuid::new_v4().to_string();
         let config = {
             let s = state.lock().await;

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -336,6 +336,18 @@ pub fn parse_issue_from_title(title: &str) -> Option<u64> {
     None
 }
 
+/// Fetch the current state of an issue (e.g. "OPEN", "CLOSED").
+/// Returns the state string or an error if the check fails.
+pub fn get_issue_state(repo: &str, issue_number: u64) -> Result<String, String> {
+    let num_str = issue_number.to_string();
+    let output = run_gh(&[
+        "issue", "view", &num_str, "-R", repo, "--json", "state",
+    ])?;
+    let v: serde_json::Value =
+        serde_json::from_str(&output).map_err(|e| format!("Failed to parse issue JSON: {}", e))?;
+    Ok(v["state"].as_str().unwrap_or("OPEN").to_string())
+}
+
 /// Check if a PR associated with a given issue number is actually merged.
 /// Returns Ok(true) if merged, Ok(false) if still open/closed-not-merged, Err on failure.
 pub fn is_pr_merged_for_issue(repo: &str, issue_number: u64) -> Result<bool, String> {


### PR DESCRIPTION
Closes #25

## Summary

- Added `github::get_issue_state()` helper to fetch an issue's current state (OPEN/CLOSED)
- Added a state-check block in `spawn_next_stage()` that runs before creating a new agent run:
  - If the issue is no longer open (closed externally), the stage is skipped
  - If the next stage is Merge and the PR is already merged, the stage is skipped
  - If the check itself fails, a warning is logged and the pipeline proceeds (fail-open, matching existing merge verification behavior)

## Test plan

- [ ] Verify pipeline skips remaining stages when an issue is closed externally between stages
- [ ] Verify Merge stage is skipped when the PR was already merged externally
- [ ] Verify pipeline proceeds normally when checks fail (e.g. network error)
- [ ] Verify normal auto-chaining still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)