### PR TITLE
Add manual stage advancement for tasks when auto-run is off

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -445,55 +445,86 @@ pub async fn advance_to_stage(
 ) -> Result<String, String> {
     let target = parse_stage(&target_stage, false)?;
 
-    let (repo, issue_number, issue_title, workspace_path, issue_labels, previous_context) = {
+    let (
+        repo,
+        issue_number,
+        issue_title,
+        current_stage,
+        current_status,
+        workspace_path,
+        issue_labels,
+        previous_context,
+        max_retries,
+        auto_pilot_running,
+    ) = {
         let s = state.lock().await;
         let run = s.runs.get(&run_id).ok_or("Run not found")?;
-        match run.status {
-            AgentStatus::Completed
-            | AgentStatus::AwaitingApproval
-            | AgentStatus::Failed
-            | AgentStatus::Stopped
-            | AgentStatus::Interrupted => {}
-            _ => {
-                return Err(format!(
-                    "Cannot advance run {} with status {:?}",
-                    run_id, run.status
-                ));
-            }
-        }
-        if run.stage == PipelineStage::Done {
-            return Err("Cannot advance a completed pipeline".to_string());
-        }
         (
             run.repo.clone(),
             run.issue_number,
             run.issue_title.clone(),
+            run.stage.clone(),
+            run.status.clone(),
             run.workspace_path.clone(),
             run.issue_labels.clone(),
             run.stage_context.clone(),
+            s.config.max_retries,
+            s.is_running,
         )
     };
 
-    // Mark current run as completed before advancing
-    let _ = runtime::transition_run(
-        &app,
-        state.inner(),
-        &run_id,
-        StatusTransition {
-            status: AgentStatus::Completed,
-            stage_label: "advanced".to_string(),
-            error: None,
-            finished: true,
-            log_message: Some(format!(
-                "[manual] Advanced to {} by user",
-                target_stage
-            )),
-            pending_next_stage: PendingNextStageUpdate::Clear,
-            emit_extra: Map::new(),
-            persist_meta: true,
-        },
-    )
-    .await;
+    if auto_pilot_running {
+        return Err("Can only manually advance when auto-pilot is off".to_string());
+    }
+
+    match current_status {
+        AgentStatus::Completed | AgentStatus::AwaitingApproval => {}
+        _ => {
+            return Err(format!(
+                "Cannot manually advance run {} with status {:?}",
+                run_id, current_status
+            ));
+        }
+    }
+
+    if current_stage == PipelineStage::Done {
+        return Err("Cannot advance a completed pipeline".to_string());
+    }
+
+    if !can_advance_to_stage(&current_stage, &target) {
+        return Err(format!(
+            "Can only advance to a later stage (current: {}, requested: {})",
+            current_stage, target_stage
+        ));
+    }
+
+    if current_status == AgentStatus::AwaitingApproval {
+        let _ = runtime::transition_run(
+            &app,
+            state.inner(),
+            &run_id,
+            StatusTransition {
+                status: AgentStatus::Completed,
+                stage_label: "advanced".to_string(),
+                error: None,
+                finished: false,
+                log_message: Some(format!("[manual] Advanced to {} by user", target_stage)),
+                pending_next_stage: PendingNextStageUpdate::Clear,
+                emit_extra: Map::new(),
+                persist_meta: true,
+            },
+        )
+        .await;
+    } else {
+        runtime::append_run_log(
+            state.inner(),
+            &run_id,
+            format!("[manual] Advanced to {} by user", target_stage),
+            true,
+            false,
+        )
+        .await;
+    }
 
     let workspace_exists = workspace::workspace_exists(&repo, issue_number);
     let effective_stage = if workspace_exists {
@@ -518,17 +549,25 @@ pub async fn advance_to_stage(
         Err(_) => String::new(),
     };
 
-    launch_agent(
+    spawn_next_stage(
         app,
         state.inner().clone(),
-        repo,
-        issue_number,
-        issue_title,
-        body,
-        effective_stage,
-        issue_labels,
-    )
-    .await
+        StageLaunchSpec {
+            repo,
+            issue_number,
+            issue_title,
+            issue_body: body,
+            stage: effective_stage,
+            issue_labels,
+            workspace_path: std::path::PathBuf::from(workspace_path),
+            attempt: 1,
+            max_retries,
+            previous_error: String::new(),
+            previous_context,
+        },
+    );
+
+    Ok(run_id)
 }
 
 fn parse_stage(stage_name: &str, allow_done: bool) -> Result<PipelineStage, String> {
@@ -539,5 +578,44 @@ fn parse_stage(stage_name: &str, allow_done: bool) -> Result<PipelineStage, Stri
         "merge" => Ok(PipelineStage::Merge),
         "done" if allow_done => Ok(PipelineStage::Done),
         _ => Err(format!("Invalid stage: {}", stage_name)),
+    }
+}
+
+fn can_advance_to_stage(current: &PipelineStage, target: &PipelineStage) -> bool {
+    stage_rank(target) > stage_rank(current)
+}
+
+fn stage_rank(stage: &PipelineStage) -> u8 {
+    match stage {
+        PipelineStage::Implement => 0,
+        PipelineStage::CodeReview => 1,
+        PipelineStage::Testing => 2,
+        PipelineStage::Merge => 3,
+        PipelineStage::Done => 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{can_advance_to_stage, PipelineStage};
+
+    #[test]
+    fn manual_advance_requires_a_later_stage() {
+        assert!(can_advance_to_stage(
+            &PipelineStage::Implement,
+            &PipelineStage::CodeReview
+        ));
+        assert!(can_advance_to_stage(
+            &PipelineStage::CodeReview,
+            &PipelineStage::Merge
+        ));
+        assert!(!can_advance_to_stage(
+            &PipelineStage::Testing,
+            &PipelineStage::Testing
+        ));
+        assert!(!can_advance_to_stage(
+            &PipelineStage::Testing,
+            &PipelineStage::Implement
+        ));
     }
 }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -434,6 +434,101 @@ pub async fn stop_agent(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn advance_to_stage(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+    run_id: String,
+    target_stage: String,
+) -> Result<String, String> {
+    let target = parse_stage(&target_stage, false)?;
+
+    let (repo, issue_number, issue_title, workspace_path, issue_labels, previous_context) = {
+        let s = state.lock().await;
+        let run = s.runs.get(&run_id).ok_or("Run not found")?;
+        match run.status {
+            AgentStatus::Completed
+            | AgentStatus::AwaitingApproval
+            | AgentStatus::Failed
+            | AgentStatus::Stopped
+            | AgentStatus::Interrupted => {}
+            _ => {
+                return Err(format!(
+                    "Cannot advance run {} with status {:?}",
+                    run_id, run.status
+                ));
+            }
+        }
+        if run.stage == PipelineStage::Done {
+            return Err("Cannot advance a completed pipeline".to_string());
+        }
+        (
+            run.repo.clone(),
+            run.issue_number,
+            run.issue_title.clone(),
+            run.workspace_path.clone(),
+            run.issue_labels.clone(),
+            run.stage_context.clone(),
+        )
+    };
+
+    // Mark current run as completed before advancing
+    let _ = runtime::transition_run(
+        &app,
+        state.inner(),
+        &run_id,
+        StatusTransition {
+            status: AgentStatus::Completed,
+            stage_label: "advanced".to_string(),
+            error: None,
+            finished: true,
+            log_message: Some(format!(
+                "[manual] Advanced to {} by user",
+                target_stage
+            )),
+            pending_next_stage: PendingNextStageUpdate::Clear,
+            emit_extra: Map::new(),
+            persist_meta: true,
+        },
+    )
+    .await;
+
+    let workspace_exists = workspace::workspace_exists(&repo, issue_number);
+    let effective_stage = if workspace_exists {
+        target
+    } else {
+        runtime::append_run_log(
+            state.inner(),
+            &run_id,
+            format!(
+                "[manual] Workspace missing, falling back to implement (requested: {})",
+                target_stage
+            ),
+            true,
+            false,
+        )
+        .await;
+        PipelineStage::Implement
+    };
+
+    let body = match crate::github::get_issue_detail(repo.clone(), issue_number).await {
+        Ok(issue) => issue.body.unwrap_or_default(),
+        Err(_) => String::new(),
+    };
+
+    launch_agent(
+        app,
+        state.inner().clone(),
+        repo,
+        issue_number,
+        issue_title,
+        body,
+        effective_stage,
+        issue_labels,
+    )
+    .await
+}
+
 fn parse_stage(stage_name: &str, allow_done: bool) -> Result<PipelineStage, String> {
     match stage_name {
         "implement" => Ok(PipelineStage::Implement),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run() {
             agent::retry_agent_from_stage,
             agent::approve_stage,
             agent::reject_stage,
+            agent::advance_to_stage,
             agent::get_default_prompts,
             orchestrator::get_pipeline_report,
             orchestrator::search_agent_logs,

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -26,6 +26,7 @@ export function Dashboard({ onViewLogs, onViewReport }: DashboardProps) {
       onRetryAgentFromStage={controller.retryAgentFromStage}
       onApproveStage={controller.approveStage}
       onRejectStage={controller.rejectStage}
+      onAdvanceToStage={controller.advanceToStage}
       onLaunchIssueByKey={controller.launchIssueByKey}
     />
   );

--- a/src/features/dashboard/DashboardBoard.test.tsx
+++ b/src/features/dashboard/DashboardBoard.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DashboardBoard } from "./DashboardBoard";
+import type { DashboardColumn } from "./types";
+
+const columns: DashboardColumn[] = [
+  {
+    id: "review",
+    title: "Code Review",
+    color: "#bc8cff",
+    items: [
+      {
+        id: "run-1",
+        issueKey: "pedrocid/SymphonyMac:74",
+        repo: "pedrocid/SymphonyMac",
+        number: 74,
+        title: "Manual stage advancement",
+        labels: [],
+        assignee: null,
+        updated: "Just now",
+        runId: "run-1",
+        runStatus: "waiting",
+        runStage: "implement",
+      },
+    ],
+  },
+];
+
+function renderBoard(manualAdvanceEnabled: boolean) {
+  const onAdvanceToStage = vi.fn();
+
+  render(
+    <DashboardBoard
+      columns={columns}
+      manualAdvanceEnabled={manualAdvanceEnabled}
+      showRepoName={false}
+      onViewLogs={vi.fn()}
+      onViewReport={vi.fn()}
+      onLaunchIssueByKey={vi.fn()}
+      onStopAgent={vi.fn()}
+      onRetryAgent={vi.fn()}
+      onRetryAgentFromStage={vi.fn()}
+      onApproveStage={vi.fn()}
+      onRejectStage={vi.fn()}
+      onAdvanceToStage={onAdvanceToStage}
+    />,
+  );
+
+  return { onAdvanceToStage };
+}
+
+describe("DashboardBoard", () => {
+  it("shows manual advance actions when auto-pilot is off", () => {
+    const { onAdvanceToStage } = renderBoard(true);
+
+    expect(screen.getByText("Ready for manual advance")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Testing" }));
+
+    expect(onAdvanceToStage).toHaveBeenCalledWith("run-1", "testing");
+  });
+
+  it("hides manual advance actions while auto-pilot is running", () => {
+    renderBoard(false);
+
+    expect(screen.getByText("Starting next stage...")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Review" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Testing" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Merge" })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard/DashboardBoard.tsx
+++ b/src/features/dashboard/DashboardBoard.tsx
@@ -25,6 +25,7 @@ function getAdvanceableStages(currentStage: string | undefined): string[] {
 
 interface DashboardBoardProps {
   columns: DashboardColumn[];
+  manualAdvanceEnabled: boolean;
   showRepoName: boolean;
   onViewLogs: (runId: string) => void;
   onViewReport?: (runId: string) => void;
@@ -39,6 +40,7 @@ interface DashboardBoardProps {
 
 export function DashboardBoard({
   columns,
+  manualAdvanceEnabled,
   showRepoName,
   onViewLogs,
   onViewReport,
@@ -70,6 +72,7 @@ export function DashboardBoard({
                   card={card}
                   columnId={column.id}
                   color={column.color}
+                  manualAdvanceEnabled={manualAdvanceEnabled}
                   showRepoName={showRepoName}
                   onViewLogs={onViewLogs}
                   onViewReport={onViewReport}
@@ -94,10 +97,15 @@ export function DashboardBoard({
   );
 }
 
-interface DashboardCardProps extends Omit<DashboardBoardProps, "columns" | "showRepoName"> {
+interface DashboardCardProps
+  extends Omit<
+    DashboardBoardProps,
+    "columns" | "manualAdvanceEnabled" | "showRepoName"
+  > {
   card: KanbanCard;
   color: string;
   columnId: string;
+  manualAdvanceEnabled: boolean;
   showRepoName: boolean;
 }
 
@@ -105,6 +113,7 @@ function DashboardCard({
   card,
   color,
   columnId,
+  manualAdvanceEnabled,
   showRepoName,
   onViewLogs,
   onViewReport,
@@ -116,6 +125,16 @@ function DashboardCard({
   onRejectStage,
   onAdvanceToStage,
 }: DashboardCardProps) {
+  const canAdvanceManually =
+    manualAdvanceEnabled &&
+    !!card.runId &&
+    !!card.runStage &&
+    card.runStage !== "done" &&
+    (card.runStatus === "waiting" || card.runStatus === "awaiting_approval");
+  const advanceableStages = canAdvanceManually
+    ? getAdvanceableStages(card.runStage)
+    : [];
+
   return (
     <div
       className="bg-[#161b22] border border-[#30363d] rounded-lg p-3 hover:border-[#484f58] transition-colors cursor-pointer group"
@@ -152,8 +171,14 @@ function DashboardCard({
 
       {card.runStatus === "waiting" && (
         <div className="flex items-center gap-1.5 mb-2">
-          <span className="w-1.5 h-1.5 bg-[#484f58] rounded-full animate-pulse" />
-          <span className="text-xs text-[#484f58]">Starting next stage...</span>
+          <span
+            className={`w-1.5 h-1.5 rounded-full ${
+              manualAdvanceEnabled ? "bg-[#58a6ff]" : "bg-[#484f58] animate-pulse"
+            }`}
+          />
+          <span className={`text-xs ${manualAdvanceEnabled ? "text-[#58a6ff]" : "text-[#484f58]"}`}>
+            {manualAdvanceEnabled ? "Ready for manual advance" : "Starting next stage..."}
+          </span>
         </div>
       )}
 
@@ -194,32 +219,28 @@ function DashboardCard({
         </div>
       )}
 
-      {card.runStatus === "completed" && card.runId && card.runStage && card.runStage !== "done" && (() => {
-        const stages = getAdvanceableStages(card.runStage);
-        if (stages.length === 0) return null;
-        return (
-          <div className="mb-2">
-            <div className="flex items-center gap-1.5 mb-2">
-              <span className="w-1.5 h-1.5 bg-[#58a6ff] rounded-full" />
-              <span className="text-xs text-[#58a6ff]">Advance to next stage</span>
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {stages.map((stage) => (
-                <button
-                  key={stage}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onAdvanceToStage(card.runId!, stage);
-                  }}
-                  className="px-2 py-0.5 text-xs font-medium bg-[#58a6ff15] text-[#58a6ff] border border-[#58a6ff] rounded-md hover:bg-[#58a6ff30] transition-colors"
-                >
-                  {STAGE_DISPLAY[stage] || stage}
-                </button>
-              ))}
-            </div>
+      {advanceableStages.length > 0 && (
+        <div className="mb-2">
+          <div className="flex items-center gap-1.5 mb-2">
+            <span className="w-1.5 h-1.5 bg-[#58a6ff] rounded-full" />
+            <span className="text-xs text-[#58a6ff]">Advance manually</span>
           </div>
-        );
-      })()}
+          <div className="flex flex-wrap gap-1.5">
+            {advanceableStages.map((stage) => (
+              <button
+                key={stage}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onAdvanceToStage(card.runId!, stage);
+                }}
+                className="px-2 py-0.5 text-xs font-medium bg-[#58a6ff15] text-[#58a6ff] border border-[#58a6ff] rounded-md hover:bg-[#58a6ff30] transition-colors"
+              >
+                {STAGE_DISPLAY[stage] || stage}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {card.blockedBy && card.blockedBy.length > 0 && (
         <div className="flex items-center gap-1.5 mb-2">

--- a/src/features/dashboard/DashboardBoard.tsx
+++ b/src/features/dashboard/DashboardBoard.tsx
@@ -7,6 +7,22 @@ const STAGE_LABELS: Record<string, string> = {
   merge: "Merging",
 };
 
+const STAGE_ORDER = ["implement", "code_review", "testing", "merge"];
+
+const STAGE_DISPLAY: Record<string, string> = {
+  implement: "Implement",
+  code_review: "Review",
+  testing: "Testing",
+  merge: "Merge",
+};
+
+function getAdvanceableStages(currentStage: string | undefined): string[] {
+  if (!currentStage) return STAGE_ORDER;
+  const idx = STAGE_ORDER.indexOf(currentStage);
+  if (idx < 0) return [];
+  return STAGE_ORDER.slice(idx + 1);
+}
+
 interface DashboardBoardProps {
   columns: DashboardColumn[];
   showRepoName: boolean;
@@ -18,6 +34,7 @@ interface DashboardBoardProps {
   onRetryAgentFromStage: (runId: string, fromStage: string) => void;
   onApproveStage: (runId: string) => void;
   onRejectStage: (runId: string) => void;
+  onAdvanceToStage: (runId: string, targetStage: string) => void;
 }
 
 export function DashboardBoard({
@@ -31,6 +48,7 @@ export function DashboardBoard({
   onRetryAgentFromStage,
   onApproveStage,
   onRejectStage,
+  onAdvanceToStage,
 }: DashboardBoardProps) {
   return (
     <div className="flex-1 overflow-x-auto overflow-y-hidden p-6">
@@ -61,6 +79,7 @@ export function DashboardBoard({
                   onRetryAgentFromStage={onRetryAgentFromStage}
                   onApproveStage={onApproveStage}
                   onRejectStage={onRejectStage}
+                  onAdvanceToStage={onAdvanceToStage}
                 />
               ))}
 
@@ -95,6 +114,7 @@ function DashboardCard({
   onRetryAgentFromStage,
   onApproveStage,
   onRejectStage,
+  onAdvanceToStage,
 }: DashboardCardProps) {
   return (
     <div
@@ -173,6 +193,33 @@ function DashboardCard({
           </div>
         </div>
       )}
+
+      {card.runStatus === "completed" && card.runId && card.runStage && card.runStage !== "done" && (() => {
+        const stages = getAdvanceableStages(card.runStage);
+        if (stages.length === 0) return null;
+        return (
+          <div className="mb-2">
+            <div className="flex items-center gap-1.5 mb-2">
+              <span className="w-1.5 h-1.5 bg-[#58a6ff] rounded-full" />
+              <span className="text-xs text-[#58a6ff]">Advance to next stage</span>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {stages.map((stage) => (
+                <button
+                  key={stage}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onAdvanceToStage(card.runId!, stage);
+                  }}
+                  className="px-2 py-0.5 text-xs font-medium bg-[#58a6ff15] text-[#58a6ff] border border-[#58a6ff] rounded-md hover:bg-[#58a6ff30] transition-colors"
+                >
+                  {STAGE_DISPLAY[stage] || stage}
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
 
       {card.blockedBy && card.blockedBy.length > 0 && (
         <div className="flex items-center gap-1.5 mb-2">

--- a/src/features/dashboard/DashboardView.tsx
+++ b/src/features/dashboard/DashboardView.tsx
@@ -75,6 +75,7 @@ export function DashboardView({
 
       <DashboardBoard
         columns={columns}
+        manualAdvanceEnabled={!status.is_running}
         showRepoName={status.repos.length > 1}
         onViewLogs={onViewLogs}
         onViewReport={onViewReport}

--- a/src/features/dashboard/DashboardView.tsx
+++ b/src/features/dashboard/DashboardView.tsx
@@ -15,6 +15,7 @@ interface DashboardViewProps {
   onRetryAgentFromStage: (runId: string, fromStage: string) => void;
   onApproveStage: (runId: string) => void;
   onRejectStage: (runId: string) => void;
+  onAdvanceToStage: (runId: string, targetStage: string) => void;
   onLaunchIssueByKey: (issueKey: string) => void;
 }
 
@@ -30,6 +31,7 @@ export function DashboardView({
   onRetryAgentFromStage,
   onApproveStage,
   onRejectStage,
+  onAdvanceToStage,
   onLaunchIssueByKey,
 }: DashboardViewProps) {
   const title = status.repos.length > 0 ? status.repos.join(", ") : "Symphony";
@@ -82,6 +84,7 @@ export function DashboardView({
         onRetryAgentFromStage={onRetryAgentFromStage}
         onApproveStage={onApproveStage}
         onRejectStage={onRejectStage}
+        onAdvanceToStage={onAdvanceToStage}
       />
     </div>
   );

--- a/src/features/dashboard/useDashboardController.ts
+++ b/src/features/dashboard/useDashboardController.ts
@@ -2,6 +2,7 @@ import { startTransition, useState } from "react";
 import { useStatusPolling } from "../../hooks/useStatusPolling";
 import { useTauriSubscription } from "../../hooks/useTauriSubscription";
 import {
+  advanceToStage,
   approveStage,
   getStatus,
   listIssuesForRepos,
@@ -84,6 +85,8 @@ export function useDashboardController() {
       runAndRefresh(() => retryAgentFromStage(runId, fromStage)),
     approveStage: (runId: string) => runAndRefresh(() => approveStage(runId)),
     rejectStage: (runId: string) => runAndRefresh(() => rejectStage(runId)),
+    advanceToStage: (runId: string, targetStage: string) =>
+      runAndRefresh(() => advanceToStage(runId, targetStage)),
     launchIssueByKey: (issueKey: string) => {
       const issue = issuesByKey.get(issueKey);
       if (!issue) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -104,6 +104,10 @@ export async function rejectStage(runId: string): Promise<void> {
   await command<void>("reject_stage", { runId });
 }
 
+export async function advanceToStage(runId: string, targetStage: string): Promise<void> {
+  await command<void>("advance_to_stage", { runId, targetStage });
+}
+
 export async function updateConfig(config: RunConfig): Promise<void> {
   await command<void>("update_config", { config });
 }


### PR DESCRIPTION
When approval gates are enabled (auto-run off), users can now manually
advance a task to any subsequent pipeline stage directly from the
Kanban board. Adds advance_to_stage Tauri command and UI buttons on
completed cards showing available next stages.

https://claude.ai/code/session_01LjYYPpxbLYJGEawTvYg5wU